### PR TITLE
Bring packaging metadata in line with stated supported versions of Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     packages=find_packages(),
     package_data={'ifaddr': ['py.typed']},
     license='MIT',
+    python_requires=">=3.8",
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
See #55 -- there's no fixing 0.2.0 short of yanking it, but at least the next release will be better.