### PR TITLE
Drop Python 3.7 from classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'Topic :: System :: Networking',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Support for Python 3.7 has officially been removed from the library, hence remove it from the classifiers list.