### PR TITLE
Fix: drop Python 3.7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 110
-target_version = ['py37', 'py38', 'py39', 'py310']
+target_version = ['py38', 'py39', 'py310']
 skip_string_normalization = true


### PR DESCRIPTION
Fixup for e389d298536c4d46770cdf044bb08e828afa0da5