### PR TITLE
Switch the GHA setup to use uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,18 @@ jobs:
         python-version: [3.9, "3.10", 3.11, 3.12, 3.13, pypy3.9, pypy3.10]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Install uv and set the python version
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: |
-        pip install --upgrade '.[dev]'
+      run: uv sync
     - name: Run tests
       shell: bash
       run: |
-        pytest
-        if which mypy; then mypy ifaddr; fi
-        if which black; then black --check . ; fi
+        uv run pytest
+        if uv run which mypy; then uv run mypy ifaddr; fi
+        if uv run which black; then uv run black --check . ; fi
     # Coveralls won't work here trivially because it can't ingest coverage.xml, so Codecov it is.
     # https://github.com/coverallsapp/github-action/issues/30
     - name: Report coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "IP addresses",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "black ; implementation_name == 'cpython'",
     "mypy ; implementation_name == 'cpython'",

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ name = "ifaddr"
 version = "0.2.0"
 source = { editable = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "black", marker = "implementation_name == 'cpython'" },
     { name = "mypy", marker = "implementation_name == 'cpython'" },
@@ -156,14 +156,15 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "black", marker = "implementation_name == 'cpython' and extra == 'dev'" },
-    { name = "mypy", marker = "implementation_name == 'cpython' and extra == 'dev'" },
-    { name = "netifaces", marker = "sys_platform != 'win32' and extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", marker = "implementation_name == 'cpython'" },
+    { name = "mypy", marker = "implementation_name == 'cpython'" },
+    { name = "netifaces", marker = "sys_platform != 'win32'" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
Mostly I wanted to convert the optional dependencies to dependency groups so that the dependencies aren't published and are synced by local uv sync commands out of the box.

That more or less requires uv to be present in the CI workflow which is fine by me.